### PR TITLE
Add option to show element labels in lists

### DIFF
--- a/Editor.Samples/Collections/Collections_ListDrawerSettingsSample.cs
+++ b/Editor.Samples/Collections/Collections_ListDrawerSettingsSample.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using TriInspector;
 using UnityEngine;
 
@@ -12,4 +13,18 @@ public class Collections_ListDrawerSettingsSample : ScriptableObject
 
     [ListDrawerSettings(Draggable = false, AlwaysExpanded = true)]
     public Vector3[] vectors;
+
+    [ListDrawerSettings(ShowElementLabels = true)]
+    public MyStruct[] namedStructs = new MyStruct[]
+    {
+        new MyStruct {name = "First", value = 1},
+        new MyStruct {name = "Second", value = 2,},
+    };
+
+    [Serializable]
+    public struct MyStruct
+    {
+        public string name;
+        public int value;
+    }
 }

--- a/Editor/TriProperty.cs
+++ b/Editor/TriProperty.cs
@@ -127,6 +127,10 @@ namespace TriInspector
                     {
                         _displayNameBackingField.text = specialName;
                     }
+                    else
+                    {
+                        _displayNameBackingField.text = TriUnityInspectorUtilities.GetStandardArrayElementName(this);
+                    }
                 }
                 else
                 {

--- a/Editor/TriPropertyOverrideContext.cs
+++ b/Editor/TriPropertyOverrideContext.cs
@@ -28,6 +28,7 @@ namespace TriInspector
             {
                 _previousContext = Current;
                 Current = Override;
+                Override = null;
                 return this;
             }
 

--- a/Editor/Utilities/TriUnityInspectorUtilities.cs
+++ b/Editor/Utilities/TriUnityInspectorUtilities.cs
@@ -1,10 +1,13 @@
-﻿using System.Reflection;
+﻿using System.Collections.Generic;
+using System.Reflection;
 using UnityEngine;
 
 namespace TriInspector.Utilities
 {
     public class TriUnityInspectorUtilities
     {
+        private static readonly Dictionary<int, string> StandardArrayElementNames = new Dictionary<int, string>();
+        
         private static readonly FieldInfo GUIStyleNameBackingField = typeof(GUIStyle)
             .GetField("m_Name", BindingFlags.Instance | BindingFlags.NonPublic);
 
@@ -17,6 +20,18 @@ namespace TriInspector.Utilities
             }
 
             return !property.IsArray && property.TryGetAttribute(out DrawWithUnityAttribute _);
+        }
+
+        public static string GetStandardArrayElementName(TriProperty property)
+        {
+            var index = property.IndexInArray;
+
+            if (!StandardArrayElementNames.TryGetValue(index, out var name))
+            {
+                StandardArrayElementNames[index] = name = $"Element {index}";
+            }
+
+            return name;
         }
 
         public static bool TryGetSpecialArrayElementName(TriProperty property, out string name)
@@ -32,7 +47,8 @@ namespace TriInspector.Utilities
                 property.ChildrenProperties.Count > 0 &&
                 property.ChildrenProperties[0] is var firstChild &&
                 firstChild.ValueType == typeof(string) &&
-                firstChild.Value is string firstChildValueStr)
+                firstChild.Value is string firstChildValueStr &&
+                !string.IsNullOrEmpty(firstChildValueStr))
             {
                 name = firstChildValueStr;
                 return true;

--- a/Runtime/Attributes/ListDrawerSettings.cs
+++ b/Runtime/Attributes/ListDrawerSettings.cs
@@ -11,5 +11,6 @@ namespace TriInspector
         public bool HideAddButton { get; set; }
         public bool HideRemoveButton { get; set; }
         public bool AlwaysExpanded { get; set; }
+        public bool ShowElementLabels { get; set; }
     }
 }


### PR DESCRIPTION
![ShowElementLabels](https://github.com/codewriter-packages/Tri-Inspector/assets/26966368/a967195a-3e6e-4389-863c-92bcdc5a0c75)

```csharp
[ListDrawerSettings(ShowElementLabels = true)]
public int[] ints;

[ListDrawerSettings(ShowElementLabels = true)]
public List<NamedStruct> namedStructs;

[Serializable]
public struct NamedStruct
{
    public string name;
    public int value;
}
```

Fix #123
Fix #115 