### PR TITLE
Support Foldout SerializedProperty

### DIFF
--- a/Editor/Utilities/TriEditorGUI.cs
+++ b/Editor/Utilities/TriEditorGUI.cs
@@ -8,7 +8,16 @@ namespace TriInspector.Utilities
         public static void Foldout(Rect rect, TriProperty property)
         {
             var content = property.DisplayNameContent;
-            property.IsExpanded = EditorGUI.Foldout(rect, property.IsExpanded, content, true);
+            if (property.TryGetSerializedProperty(out var serializedProperty))
+            {
+                EditorGUI.BeginProperty(rect, content, serializedProperty);
+                property.IsExpanded = EditorGUI.Foldout(rect, property.IsExpanded, content, true);
+                EditorGUI.EndProperty();
+            }
+            else
+            {
+                property.IsExpanded = EditorGUI.Foldout(rect, property.IsExpanded, content, true);
+            }
         }
 
         public static void DrawBox(Rect position, GUIStyle style,


### PR DESCRIPTION
Wrap foldout with `BeginProperty` and `EndProperty` if available.

This enables the context menu on struct foldout which allows user to copy and paste an entire foldout.

![image](https://github.com/codewriter-packages/Tri-Inspector/assets/3797859/028397ff-a9ea-440d-8c4d-506e6e501903)