### PR TITLE
Fix TooltipAttribute not working and expose TriEditor.OnEnable and TriEditor.OnDisable

### DIFF
--- a/Editor/Editors/TriEditor.cs
+++ b/Editor/Editors/TriEditor.cs
@@ -7,12 +7,12 @@ namespace TriInspector.Editors
     {
         private TriEditorCore _core;
 
-        private void OnEnable()
+        protected virtual void OnEnable()
         {
             _core = new TriEditorCore(this);
         }
 
-        private void OnDisable()
+        protected virtual void OnDisable()
         {
             _core.Dispose();
         }

--- a/Editor/Elements/TriLabelElement.cs
+++ b/Editor/Elements/TriLabelElement.cs
@@ -6,9 +6,14 @@ namespace TriInspector.Elements
     {
         private readonly GUIContent _label;
 
-        public TriLabelElement(string label)
+        public TriLabelElement(string label, string tooltip = "")
         {
-            _label = new GUIContent(label);
+            _label = new GUIContent(label, tooltip);
+        }
+
+        public TriLabelElement(GUIContent label)
+        {
+            _label = label;
         }
 
         public override float GetHeight(float width)

--- a/Editor/TriPropertyDefinition.cs
+++ b/Editor/TriPropertyDefinition.cs
@@ -102,6 +102,10 @@ namespace TriInspector
             {
                 CustomTooltip = ValueResolver.ResolveString(this, tooltipAttribute.Tooltip);
             }
+            else if (Attributes.TryGet(out TooltipAttribute unityTooltipAttribute))
+            {
+                CustomTooltip = new ConstantValueResolver<string>(unityTooltipAttribute.tooltip);
+            }
         }
 
         public Type OwnerType { get; }


### PR DESCRIPTION
- Expose `TriEditor`'s `OnEnable`/`OnDisable` methods to prevent them from getting silently shadowed
- Fix Unity's `TooltipAttribute` not being shown
