### PR TITLE
Allow short member names for static resolvers

### DIFF
--- a/Editor/Resolvers/StaticMethodValueResolver.cs
+++ b/Editor/Resolvers/StaticMethodValueResolver.cs
@@ -12,17 +12,23 @@ namespace TriInspector.Resolvers
         public static bool TryResolve(TriPropertyDefinition propertyDefinition, string expression,
             out ValueResolver<T> resolver)
         {
-            if (expression.IndexOf('.') == -1)
+            var type = propertyDefinition.OwnerType;
+            var methodName = expression;
+            
+            var separatorIndex = expression.LastIndexOf('.');
+            if (separatorIndex >= 0)
             {
-                resolver = null;
-                return false;
+                var className = expression.Substring(0, separatorIndex);
+                methodName = expression.Substring(separatorIndex + 1);
+
+                if (!TriReflectionUtilities.TryFindTypeByFullName(className, out type))
+                {
+                    resolver = null;
+                    return false;
+                }
             }
 
-            var separatorIndex = expression.LastIndexOf('.');
-            var className = expression.Substring(0, separatorIndex);
-            var methodName = expression.Substring(separatorIndex + 1);
-
-            if (!TriReflectionUtilities.TryFindTypeByFullName(className, out var type))
+            if (type == null)
             {
                 resolver = null;
                 return false;

--- a/Editor/Resolvers/StaticPropertyValueResolver.cs
+++ b/Editor/Resolvers/StaticPropertyValueResolver.cs
@@ -12,17 +12,23 @@ namespace TriInspector.Resolvers
         public static bool TryResolve(TriPropertyDefinition propertyDefinition, string expression,
             out ValueResolver<T> resolver)
         {
-            if (expression.IndexOf('.') == -1)
+            var type = propertyDefinition.OwnerType;
+            var propertyName = expression;
+            
+            var separatorIndex = expression.LastIndexOf('.');
+            if (separatorIndex >= 0)
             {
-                resolver = null;
-                return false;
+                var className = expression.Substring(0, separatorIndex);
+                propertyName = expression.Substring(separatorIndex + 1);
+
+                if (!TriReflectionUtilities.TryFindTypeByFullName(className, out type))
+                {
+                    resolver = null;
+                    return false;
+                }
             }
 
-            var separatorIndex = expression.LastIndexOf('.');
-            var className = expression.Substring(0, separatorIndex);
-            var methodName = expression.Substring(separatorIndex + 1);
-
-            if (!TriReflectionUtilities.TryFindTypeByFullName(className, out var type))
+            if (type == null)
             {
                 resolver = null;
                 return false;
@@ -32,7 +38,7 @@ namespace TriInspector.Resolvers
 
             foreach (var propertyInfo in type.GetProperties(flags))
             {
-                if (propertyInfo.Name == methodName &&
+                if (propertyInfo.Name == propertyName &&
                     typeof(T).IsAssignableFrom(propertyInfo.PropertyType) &&
                     propertyInfo.CanRead)
                 {


### PR DESCRIPTION
Changes static resolvers to attempt to resolve on the property's owner type if given a member name without the `.` separator.

This adds a bit of QoL by removing the need to fully qualify the name of the static member if it's being referenced by a property under the exact same type.

For example:
```csharp
namespace Some.Long.Namespace
{
    public class Example : ScriptableObject
    {
        // old
        // [Dropdown("Some.Long.Namespace.Example.GetDropdown")
        // new
        [Dropdown(nameof(GetDropdown))]
        public string example;

        private static TriDropdownList<string> GetDropdown()
        {
            // ...
        }
    }
}
```