### PR TITLE
Ignore readonly fields

### DIFF
--- a/Editor/Utilities/TriUnitySerializationUtilities.cs
+++ b/Editor/Utilities/TriUnitySerializationUtilities.cs
@@ -14,6 +14,11 @@ namespace TriInspector.Utilities
 
         public static bool IsSerializableByUnity(FieldInfo fieldInfo)
         {
+            if (fieldInfo.IsInitOnly)
+            {
+                return false;
+            }
+
             if (fieldInfo.GetCustomAttribute<NonSerializedAttribute>() != null ||
                 fieldInfo.GetCustomAttribute<HideInInspector>() != null)
             {


### PR DESCRIPTION
I believe Unity does not serialize `readonly` fields.

I've checked in Unity 2022.3.32f using this really simple script.

```
using UnityEngine;
public class Test : MonoBehaviour
{
    public readonly int ReadonlyValue = 1;
    public int Value = 2;
}
```

Unity:
![image](https://github.com/codewriter-packages/Tri-Inspector/assets/3797859/fdfbe406-c298-47b9-9e26-d95f0fc534b6)

TriInspector (1.14.0):
![image](https://github.com/codewriter-packages/Tri-Inspector/assets/3797859/ea6e7e25-1d00-45ac-b76c-82b9df10eb56)

Debug (for reference):
![image](https://github.com/codewriter-packages/Tri-Inspector/assets/3797859/7a2e434c-a250-4908-8890-a8ecd319117d)