### PR TITLE
Adds AnimatorParameter and MaterialProperty attributes

### DIFF
--- a/Editor.Extras/Drawers/AnimatorParameterAttributeDrawer.cs
+++ b/Editor.Extras/Drawers/AnimatorParameterAttributeDrawer.cs
@@ -1,0 +1,396 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using TriInspector;
+using TriInspector.Drawers;
+using TriInspector.Resolvers;
+using UnityEditor;
+using UnityEngine;
+
+[assembly: RegisterTriAttributeDrawer(typeof(AnimatorParameterAttributeDrawer), TriDrawerOrder.Decorator, ApplyOnArrayElement = true)]
+
+namespace TriInspector.Drawers
+{
+    public class AnimatorParameterAttributeDrawer : TriAttributeDrawer<AnimatorParameterAttribute>
+    {
+        private AnimatorParameterHelper.ResolvedParams _resolvedParams;
+
+        public override TriExtensionInitializationResult Initialize(TriPropertyDefinition propertyDefinition)
+        {
+            _resolvedParams = AnimatorParameterHelper.Initialize(propertyDefinition, Attribute);
+
+            if (_resolvedParams.ErrorResult.IsError)
+            {
+                return TriExtensionInitializationResult.Skip;
+            }
+
+            if (propertyDefinition.FieldType != typeof(string) &&
+                propertyDefinition.FieldType != typeof(int))
+            {
+                return "[AnimationParameter] can only be used on 'string' or 'int' fields.";
+            }
+
+            return TriExtensionInitializationResult.Ok;
+        }
+        public override void OnGUI(Rect position, TriProperty property, TriElement next)
+        {
+            var animator = _resolvedParams.AnimatorResolver.GetValue(property);
+            var label = property.DisplayNameContent;
+            var (allParameters, allFilteredParameters) = AnimatorParameterHelper.GetParameters(animator, Attribute.ParameterType);
+
+            if (property.ValueType == typeof(string))
+            {
+                DrawPopup(
+                    position,
+                    label,
+                    property,
+                    animator,
+                    (string)property.Value,
+                    allParameters.Names,
+                    allFilteredParameters.Names,
+                    allFilteredParameters.DisplayNames,
+                    allFilteredParameters.Types,
+                    AnimatorParameterHelper.GetInvalidParameterLabel
+                );
+            }
+            else if (property.ValueType == typeof(int))
+            {
+                DrawPopup(
+                    position,
+                    label,
+                    property,
+                    animator,
+                    (int)property.Value,
+                    allParameters.Hashes,
+                    allFilteredParameters.Hashes,
+                    allFilteredParameters.DisplayNames,
+                    allFilteredParameters.Types,
+                    AnimatorParameterHelper.GetInvalidParameterLabel
+                );
+            }
+        }
+        private void DrawPopup<T>(
+            Rect position,
+            GUIContent label,
+            TriProperty property,
+            Animator animator,
+            T currentValue,
+            T[] allValues,
+            T[] filteredValues,
+            GUIContent[] displayNames,
+            AnimatorControllerParameterType[] types,
+            Func<Animator, T, string> invalidLabelFunc)
+        {
+            bool isEmpty = EqualityComparer<T>.Default.Equals(currentValue, default);
+            bool exists = allValues.Contains(currentValue);
+            bool matchesType = filteredValues.Contains(currentValue);
+            bool isValid = isEmpty || (exists && matchesType);
+
+            var displayList = new List<GUIContent>(displayNames);
+            var valueList = new List<T>(filteredValues);
+
+            int currentIndex = 0;
+
+            if (!isValid)
+            {
+                displayList.Add(new GUIContent(invalidLabelFunc(animator, currentValue)));
+                valueList.Add(currentValue);
+                currentIndex = valueList.Count - 1;
+            }
+            else
+            {
+                currentIndex = Array.IndexOf(filteredValues, currentValue);
+                if (currentIndex < 0) currentIndex = 0;
+            }
+
+            EditorGUI.BeginChangeCheck();
+            int newIndex = EditorGUI.Popup(position, label, currentIndex, displayList.ToArray());
+
+            if (EditorGUI.EndChangeCheck())
+            {
+                if (newIndex < 0 || newIndex >= valueList.Count)
+                    return;
+
+                T selectedValue = valueList[newIndex];
+                var selectedType = types[Mathf.Min(newIndex, types.Length - 1)];
+                string selectedName = selectedValue is string s ? s : AllParametersName(animator, selectedValue);
+
+                property.SetValue(selectedValue);
+
+                AnimatorParameterHelper.SaveSingleParameter(
+                    animator,
+                    selectedName,
+                    selectedType,
+                    Animator.StringToHash(selectedName)
+                );
+            }
+        }
+
+        private string AllParametersName(Animator animator, object value)
+        {
+            if (value is int hash)
+                return animator.parameters.FirstOrDefault(p => p.nameHash == hash)?.name ?? hash.ToString();
+            return value?.ToString();
+        }
+    }
+
+    #region Helper Class
+
+    internal static class AnimatorParameterHelper
+    {
+        internal class ResolvedParams
+        {
+            public ValueResolver<Animator> AnimatorResolver;
+            public TriExtensionInitializationResult ErrorResult;
+        }
+
+        internal struct ParameterData
+        {
+            public GUIContent[] DisplayNames;
+            public string[] Names;
+            public int[] Hashes;
+            public AnimatorControllerParameterType[] Types;
+
+            public static ParameterData Empty => new()
+            {
+                DisplayNames = new[] { new GUIContent("None") },
+                Names = new string[] { null },
+                Hashes = new[] { 0 },
+                Types = new AnimatorControllerParameterType[] { 0 }
+            };
+        }
+        
+        [Serializable]
+        private class CacheData
+        {
+            public List<ProjectEntry> projects = new();
+
+            public static CacheData Empty => new()
+            {
+                projects = new List<ProjectEntry>()
+                {
+                    new()
+                    {
+                        hash = Application.dataPath.GetHashCode(),
+                        animators = new List<AnimatorEntry>()
+                    }
+                }
+            };
+        }
+        [Serializable]
+        private class ProjectEntry
+        {
+            public int hash;
+            public List<AnimatorEntry> animators = new();
+        }
+
+        [Serializable]
+        private class AnimatorEntry
+        {
+            public string guid;
+            public List<ParameterEntry> parameters = new();
+        }
+
+        [Serializable]
+        private class ParameterEntry
+        {
+            public int hash;
+            public string name;
+            public AnimatorControllerParameterType type;
+        }
+
+        private static string CacheEditorPrefsKey => $"TriInspector.AnimationParameterCache";
+
+        private static CacheData _globalCache;
+
+        private static void LoadCache()
+        {
+            if (_globalCache != null) return;
+
+            string json = EditorPrefs.GetString(CacheEditorPrefsKey, null);
+
+            try
+            {
+                if (!string.IsNullOrEmpty(json))
+                    _globalCache = JsonUtility.FromJson<CacheData>(json);
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[TriInspector.AnimationParameter] Could not load parameter cache: {e.Message}");
+            }
+            finally
+            {
+                _globalCache ??= CacheData.Empty;
+            }
+        }
+        private static void ClearCacheMenu()
+        {
+            EditorPrefs.DeleteKey(CacheEditorPrefsKey);
+            _globalCache = null;
+            Debug.Log("[TriInspector.AnimatorProperty] Cache cleared.");
+        }
+        public static void SaveSingleParameter(Animator animator, string name, AnimatorControllerParameterType type, int hash)
+        {
+            if (animator == null || animator.runtimeAnimatorController == null)
+                return;
+
+            string guid = GetAnimatorGuid(animator);
+            if (string.IsNullOrEmpty(guid))
+                return;
+
+            int currentProjectHash = Application.dataPath.GetHashCode();
+
+            LoadCache();
+
+            var projectData = _globalCache.projects.FirstOrDefault(p => p.hash == currentProjectHash);
+            if (projectData == null)
+            {
+                projectData = new ProjectEntry { hash = currentProjectHash };
+                _globalCache.projects.Add(projectData);
+            }
+
+            var animatorData = projectData.animators.FirstOrDefault(a => a.guid == guid);
+            if (animatorData == null)
+            {
+                animatorData = new AnimatorEntry { guid = guid };
+                projectData.animators.Add(animatorData);
+            }
+
+            var validParameterNames = animator.parameters.Select(p => p.name).ToHashSet();
+            var validParameterHashes = animator.parameters.Select(p => p.nameHash).ToHashSet();
+            animatorData.parameters.RemoveAll(p =>
+                !validParameterNames.Contains(p.name) && !validParameterHashes.Contains(p.hash));
+
+            var foundEntry = animatorData.parameters.FirstOrDefault(e => e.hash == hash || e.name == name);
+
+            foundEntry ??= new ParameterEntry();
+            foundEntry.hash = hash;
+            foundEntry.name = name;
+            foundEntry.type = type;
+
+            if (!animatorData.parameters.Contains(foundEntry))
+                animatorData.parameters.Add(foundEntry);
+
+            string json = JsonUtility.ToJson(_globalCache, true);
+            EditorPrefs.SetString(CacheEditorPrefsKey, json);
+        }
+        public static ResolvedParams Initialize(TriPropertyDefinition propertyDefinition,
+            AnimatorParameterAttribute attribute)
+        {
+            var resolved = new ResolvedParams();
+            resolved.AnimatorResolver = ValueResolver.Resolve<Animator>(propertyDefinition,
+                attribute.AnimatorFieldName);
+
+            resolved.ErrorResult = resolved.AnimatorResolver.TryGetErrorString(out var error)
+                ? error
+                : TriExtensionInitializationResult.Ok;
+
+            return resolved;
+        }
+        public static (ParameterData allParameters, ParameterData allFilteredParameters) GetParameters(Animator animator, AnimatorControllerParameterType? filter)
+        {
+            ParameterData allParameters = ParameterData.Empty;
+            ParameterData allFilteredParameters = ParameterData.Empty;
+
+            if (animator == null || animator.runtimeAnimatorController == null)
+                return (allParameters, allFilteredParameters);
+
+            var parameters = animator.parameters;
+            if (parameters == null || parameters.Length == 0)
+                return (allParameters, allFilteredParameters);
+
+            allParameters = BuildParameters(parameters);
+
+            if (!filter.HasValue)
+                allFilteredParameters = allParameters;
+            else
+                allFilteredParameters = BuildParameters(parameters.Where(p => p.type == filter.Value).ToArray());
+
+
+            return (allParameters, allFilteredParameters);
+        }
+        public static string GetInvalidParameterLabel(Animator animator, string parameterName)
+        {
+            if (string.IsNullOrEmpty(parameterName))
+                return "None";
+
+            string guid = GetAnimatorGuid(animator);
+            if (string.IsNullOrEmpty(guid))
+                return $"{parameterName} (Missing)";
+
+            int projectHash = Application.dataPath.GetHashCode();
+            LoadCache();
+
+            var project = _globalCache?.projects?.FirstOrDefault(p => p.hash == projectHash);
+            var animatorData = project?.animators?.FirstOrDefault(a => a.guid == guid);
+            var match = animatorData?.parameters?.FirstOrDefault(p => p.name == parameterName);
+
+            return match != null
+                ? $"{parameterName} ({match.type})"
+                : $"{parameterName} (Missing)";
+        }
+        public static string GetInvalidParameterLabel(Animator animator, int parameterHash)
+        {
+            if (parameterHash == 0)
+                return "None";
+
+            string guid = GetAnimatorGuid(animator);
+            if (string.IsNullOrEmpty(guid))
+                return $"Unknown Hash ({parameterHash})";
+
+            int projectHash = Application.dataPath.GetHashCode();
+            LoadCache();
+
+            var project = _globalCache?.projects?.FirstOrDefault(p => p.hash == projectHash);
+            var animatorData = project?.animators?.FirstOrDefault(a => a.guid == guid);
+            var match = animatorData?.parameters?.FirstOrDefault(p => p.hash == parameterHash);
+
+            return match != null
+                ? $"{match.name} ({match.type})"
+                : $"Unknown Hash ({parameterHash})";
+        }
+        private static string GetAnimatorGuid(Animator animator)
+        {
+            if (animator == null || animator.runtimeAnimatorController == null)
+                return null;
+
+            var controllerPath = AssetDatabase.GetAssetPath(animator.runtimeAnimatorController);
+            if (string.IsNullOrEmpty(controllerPath))
+                return null;
+
+            return AssetDatabase.AssetPathToGUID(controllerPath);
+        }
+
+        private static ParameterData BuildParameters(AnimatorControllerParameter[] parameters)
+        {
+            var displayNames = new List<GUIContent>();
+            var names = new List<string>();
+            var hashes = new List<int>();
+            var types = new List<AnimatorControllerParameterType>();
+
+            displayNames.Add(new GUIContent("None"));
+            names.Add(null);
+            hashes.Add(0);
+            types.Add(0);
+
+            foreach (var param in parameters)
+            {
+                displayNames.Add(new GUIContent($"{param.name} ({param.type})", EditorGUIUtility.IconContent("UnityEditor.Graphs.AnimatorControllerTool").image));
+                names.Add(param.name);
+                hashes.Add(param.nameHash);
+                types.Add(param.type);
+            }
+
+            return new ParameterData
+            {
+                DisplayNames = displayNames.ToArray(),
+                Names = names.ToArray(),
+                Hashes = hashes.ToArray(),
+                Types = types.ToArray()
+            };
+        }
+
+    }
+
+    #endregion
+}

--- a/Editor.Extras/Drawers/AnimatorParameterAttributeDrawer.cs.meta
+++ b/Editor.Extras/Drawers/AnimatorParameterAttributeDrawer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 04cdc502641ba4b46a047d44624ad24b

--- a/Editor.Extras/Drawers/MaterialPropertyAttributeDrawer.cs
+++ b/Editor.Extras/Drawers/MaterialPropertyAttributeDrawer.cs
@@ -1,0 +1,421 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using TriInspector;
+using TriInspector.Drawers;
+using TriInspector.Resolvers;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.Rendering;
+
+[assembly: RegisterTriAttributeDrawer(typeof(MaterialPropertyAttributeDrawer), TriDrawerOrder.Decorator, ApplyOnArrayElement = true)]
+
+namespace TriInspector.Drawers
+{
+    public class MaterialPropertyAttributeDrawer : TriAttributeDrawer<MaterialPropertyAttribute>
+    {
+        private MaterialPropertyHelper.ResolvedParams _resolvedParams;
+
+        public override TriExtensionInitializationResult Initialize(TriPropertyDefinition propertyDefinition)
+        {
+            _resolvedParams = MaterialPropertyHelper.Initialize(propertyDefinition, Attribute);
+
+            if (_resolvedParams.ErrorResult.IsError)
+                return TriExtensionInitializationResult.Skip;
+
+            if (propertyDefinition.FieldType != typeof(string) &&
+                propertyDefinition.FieldType != typeof(int))
+                return "[MaterialProperty] can only be used on 'string' or 'int' fields.";
+
+            return TriExtensionInitializationResult.Ok;
+        }
+
+        public override void OnGUI(Rect position, TriProperty property, TriElement next)
+        {
+            var material = _resolvedParams.MaterialResolver.GetValue(property);
+            var label = property.DisplayNameContent;
+            var (allProperties, filteredProperties) = MaterialPropertyHelper.GetProperties(material, Attribute.PropertyType);
+
+            if (property.ValueType == typeof(string))
+            {
+                DrawPopup(
+                    position,
+                    label,
+                    property,
+                    material,
+                    (string)property.Value,
+                    allProperties.Names,
+                    filteredProperties.Names,
+                    filteredProperties.DisplayNames,
+                    filteredProperties.Types,
+                    MaterialPropertyHelper.GetInvalidPropertyLabel
+                );
+            }
+            else if (property.ValueType == typeof(int))
+            {
+                DrawPopup(
+                    position,
+                    label,
+                    property,
+                    material,
+                    (int)property.Value,
+                    allProperties.Hashes,
+                    filteredProperties.Hashes,
+                    filteredProperties.DisplayNames,
+                    filteredProperties.Types,
+                    MaterialPropertyHelper.GetInvalidPropertyLabel
+                );
+            }
+        }
+
+        private void DrawPopup<T>(
+            Rect position,
+            GUIContent label,
+            TriProperty property,
+            Material material,
+            T currentValue,
+            T[] allValues,
+            T[] filteredValues,
+            GUIContent[] displayNames,
+            ShaderPropertyType[] types,
+            Func<Material, T, string> invalidLabelFunc)
+        {
+            bool isEmpty = EqualityComparer<T>.Default.Equals(currentValue, default);
+            bool exists = allValues.Contains(currentValue);
+            bool matchesType = filteredValues.Contains(currentValue);
+            bool isValid = isEmpty || (exists && matchesType);
+
+            var displayList = new List<GUIContent>(displayNames);
+            var valueList = new List<T>(filteredValues);
+
+            int currentIndex = 0;
+
+            if (!isValid)
+            {
+                displayList.Add(new GUIContent(invalidLabelFunc(material, currentValue)));
+                valueList.Add(currentValue);
+                currentIndex = valueList.Count - 1;
+            }
+            else
+            {
+                currentIndex = Array.IndexOf(filteredValues, currentValue);
+                if (currentIndex < 0) currentIndex = 0;
+            }
+
+            EditorGUI.BeginChangeCheck();
+            int newIndex = EditorGUI.Popup(position, label, currentIndex, displayList.ToArray());
+
+            if (EditorGUI.EndChangeCheck())
+            {
+                if (newIndex < 0 || newIndex >= valueList.Count)
+                    return;
+
+                T selectedValue = valueList[newIndex];
+                var selectedType = types[Mathf.Min(newIndex, types.Length - 1)];
+                string selectedName = selectedValue is string s ? s : MaterialPropertyHelper.ResolvePropertyName(material, selectedValue);
+
+                property.SetValue(selectedValue);
+
+                MaterialPropertyHelper.SaveSingleProperty(
+                    material,
+                    selectedName,
+                    selectedType,
+                    Shader.PropertyToID(selectedName)
+                );
+            }
+        }
+    }
+
+    #region Helper Class
+
+    internal static class MaterialPropertyHelper
+    {
+        internal class ResolvedParams
+        {
+            public ValueResolver<Material> MaterialResolver;
+            public TriExtensionInitializationResult ErrorResult;
+        }
+
+        internal struct PropertyData
+        {
+            public GUIContent[] DisplayNames;
+            public string[] Names;
+            public int[] Hashes;
+            public ShaderPropertyType[] Types;
+
+            public static PropertyData Empty => new()
+            {
+                DisplayNames = new[] { new GUIContent("None") },
+                Names = new string[] { null },
+                Hashes = new int[] { 0 },
+                Types = new ShaderPropertyType[] { (ShaderPropertyType)0 }
+            };
+        }
+
+        public static ResolvedParams Initialize(TriPropertyDefinition propertyDefinition, MaterialPropertyAttribute attribute)
+        {
+            var resolved = new ResolvedParams
+            {
+                MaterialResolver = ValueResolver.Resolve<Material>(propertyDefinition, attribute.MaterialFieldName)
+            };
+
+            resolved.ErrorResult = resolved.MaterialResolver.TryGetErrorString(out var error)
+                ? error
+                : TriExtensionInitializationResult.Ok;
+
+            return resolved;
+        }
+
+        private static string CacheEditorPrefsKey => "TriInspector.MaterialPropertyCache";
+
+        [Serializable]
+        private class CacheData
+        {
+            public List<ProjectEntry> projects = new();
+
+            public static CacheData Empty => new()
+            {
+                projects = new List<ProjectEntry>()
+                {
+                    new()
+                    {
+                        hash = Application.dataPath.GetHashCode(),
+                        materials = new List<MaterialEntry>()
+                    }
+                }
+            };
+        }
+
+        [Serializable]
+        private class ProjectEntry
+        {
+            public int hash;
+            public List<MaterialEntry> materials = new();
+        }
+
+        [Serializable]
+        private class MaterialEntry
+        {
+            public string guid;
+            public List<PropertyEntry> properties = new();
+        }
+
+        [Serializable]
+        private class PropertyEntry
+        {
+            public int id;
+            public string name;
+            public ShaderPropertyType type;
+        }
+
+        private static CacheData _globalCache;
+
+        private static void LoadCache()
+        {
+            if (_globalCache != null) return;
+
+            string json = EditorPrefs.GetString(CacheEditorPrefsKey, null);
+
+            try
+            {
+                if (!string.IsNullOrEmpty(json))
+                    _globalCache = JsonUtility.FromJson<CacheData>(json);
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[TriInspector.MaterialProperty] Could not load cache: {e.Message}");
+            }
+            finally
+            {
+                _globalCache ??= CacheData.Empty;
+            }
+        }
+        private static void ClearCacheMenu()
+        {
+            EditorPrefs.DeleteKey(CacheEditorPrefsKey);
+            _globalCache = null;
+            Debug.Log("[TriInspector.MaterialProperty] Cache cleared.");
+        }
+
+        private static string GetMaterialShaderGuid(Material material)
+        {
+            if (material == null || material.shader == null)
+                return null;
+
+            var shaderPath = AssetDatabase.GetAssetPath(material.shader);
+            if (string.IsNullOrEmpty(shaderPath))
+                return null;
+
+            return AssetDatabase.AssetPathToGUID(shaderPath);
+        }
+
+        public static void SaveSingleProperty(Material material, string name, ShaderPropertyType type, int id)
+        {
+            if (material == null || material.shader == null)
+                return;
+
+            string guid = GetMaterialShaderGuid(material);
+            if (string.IsNullOrEmpty(guid))
+                return;
+
+            int currentProjectHash = Application.dataPath.GetHashCode();
+            LoadCache();
+
+            var projectData = _globalCache.projects.FirstOrDefault(p => p.hash == currentProjectHash);
+            if (projectData == null)
+            {
+                projectData = new ProjectEntry { hash = currentProjectHash };
+                _globalCache.projects.Add(projectData);
+            }
+
+            var shaderData = projectData.materials.FirstOrDefault(m => m.guid == guid);
+            if (shaderData == null)
+            {
+                shaderData = new MaterialEntry { guid = guid };
+                projectData.materials.Add(shaderData);
+            }
+
+            var validProps = EnumerateShaderProperties(material.shader).ToList();
+            var validNames = validProps.Select(p => p.name).ToHashSet();
+            var validIds = validProps.Select(p => p.id).ToHashSet();
+
+            shaderData.properties.RemoveAll(p => !validNames.Contains(p.name) && !validIds.Contains(p.id));
+
+            var entry = shaderData.properties.FirstOrDefault(p => p.id == id || p.name == name);
+            if (entry == null)
+            {
+                shaderData.properties.Add(new PropertyEntry
+                {
+                    id = id,
+                    name = name,
+                    type = type
+                });
+            }
+            else
+            {
+                entry.id = id;
+                entry.name = name;
+                entry.type = type;
+            }
+
+            string json = JsonUtility.ToJson(_globalCache, true);
+            EditorPrefs.SetString(CacheEditorPrefsKey, json);
+        }
+
+        public static (PropertyData all, PropertyData filtered) GetProperties(Material material, ShaderPropertyType? filter)
+        {
+            if (material == null || material.shader == null)
+                return (PropertyData.Empty, PropertyData.Empty);
+
+            var props = EnumerateShaderProperties(material.shader).ToList();
+            var all = BuildProperties(props);
+
+            var filtered = !filter.HasValue
+                  ? all
+                  : BuildProperties(props.Where(p => p.type == filter.Value).ToList());
+
+            return (all, filtered);
+        }
+
+        private static PropertyData BuildProperties(List<(string name, int id, ShaderPropertyType type)> props)
+        {
+            var displayNames = new List<GUIContent> { new("None") };
+            var names = new List<string> { null };
+            var hashes = new List<int> { 0 };
+            var types = new List<ShaderPropertyType> { (ShaderPropertyType)0 };
+
+            foreach (var p in props)
+            {
+                displayNames.Add(new GUIContent($"{p.name} ({p.type})", EditorGUIUtility.IconContent("TreeEditor.Material").image));
+                names.Add(p.name);
+                hashes.Add(p.id);
+                types.Add(p.type);
+            }
+
+            return new PropertyData
+            {
+                DisplayNames = displayNames.ToArray(),
+                Names = names.ToArray(),
+                Hashes = hashes.ToArray(),
+                Types = types.ToArray()
+            };
+        }
+
+        private static IEnumerable<(string name, int id, ShaderPropertyType type)> EnumerateShaderProperties(Shader shader)
+        {
+            int count = ShaderUtil.GetPropertyCount(shader);
+            for (int i = 0; i < count; i++)
+            {
+                string name = ShaderUtil.GetPropertyName(shader, i);
+                int id = Shader.PropertyToID(name);
+                var type = (ShaderPropertyType)ShaderUtil.GetPropertyType(shader, i);
+                yield return (name, id, type);
+            }
+        }
+
+        public static string ResolvePropertyName(Material material, object value)
+        {
+            if (material == null || material.shader == null)
+                return value?.ToString();
+
+            if (value is int id)
+            {
+                int count = ShaderUtil.GetPropertyCount(material.shader);
+                for (int i = 0; i < count; i++)
+                {
+                    string propName = ShaderUtil.GetPropertyName(material.shader, i);
+                    if (Shader.PropertyToID(propName) == id)
+                        return propName;
+                }
+                return id.ToString();
+            }
+
+            return value?.ToString();
+        }
+        public static string GetInvalidPropertyLabel(Material material, string propertyName)
+        {
+            if (string.IsNullOrEmpty(propertyName))
+                return "None";
+
+            string guid = GetMaterialShaderGuid(material);
+            if (string.IsNullOrEmpty(guid))
+                return $"{propertyName} (Missing)";
+
+            int projectHash = Application.dataPath.GetHashCode();
+            LoadCache();
+
+            var project = _globalCache?.projects?.FirstOrDefault(p => p.hash == projectHash);
+            var shaderData = project?.materials?.FirstOrDefault(m => m.guid == guid);
+
+            var match = shaderData?.properties?.FirstOrDefault(p => p.name == propertyName);
+
+            return match != null
+                ? $"{match.name} ({match.type})"
+                : $"{propertyName} (Missing)";
+        }
+
+        public static string GetInvalidPropertyLabel(Material material, int id)
+        {
+            if (id == 0)
+                return "None";
+
+            string guid = GetMaterialShaderGuid(material);
+            if (string.IsNullOrEmpty(guid))
+                return $"Unknown ID ({id})";
+
+            int projectHash = Application.dataPath.GetHashCode();
+            LoadCache();
+
+            var project = _globalCache?.projects?.FirstOrDefault(p => p.hash == projectHash);
+            var shaderData = project?.materials?.FirstOrDefault(m => m.guid == guid);
+
+            var match = shaderData?.properties?.FirstOrDefault(p => p.id == id);
+
+            return match != null
+                ? $"{match.name} ({match.type})"
+                : $"Unknown ID ({id})";
+        }
+    }
+
+    #endregion
+}

--- a/Editor.Extras/Drawers/MaterialPropertyAttributeDrawer.cs.meta
+++ b/Editor.Extras/Drawers/MaterialPropertyAttributeDrawer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7acab3803d3bcfc499e17dcf1d3b8163

--- a/Editor.Extras/Validators/AnimatorParameterAttributeValidator.cs
+++ b/Editor.Extras/Validators/AnimatorParameterAttributeValidator.cs
@@ -1,0 +1,85 @@
+using System.Linq;
+using TriInspector;
+using TriInspector.Drawers;
+using TriInspector.Validators;
+using UnityEngine;
+
+[assembly: RegisterTriAttributeValidator(typeof(AnimatorParameterAttributeValidator), ApplyOnArrayElement = true)]
+
+namespace TriInspector.Validators
+{
+    public class AnimatorParameterAttributeValidator : TriAttributeValidator<AnimatorParameterAttribute>
+    {
+        private AnimatorParameterHelper.ResolvedParams _resolvedParams;
+
+        public override TriExtensionInitializationResult Initialize(TriPropertyDefinition propertyDefinition)
+        {
+            _resolvedParams = AnimatorParameterHelper.Initialize(propertyDefinition, Attribute);
+            return _resolvedParams.ErrorResult;
+        }
+
+        public override TriValidationResult Validate(TriProperty property)
+        {
+            var animator = _resolvedParams.AnimatorResolver.GetValue(property);
+
+            if (animator == null)
+            {
+                return TriValidationResult.Error("Animator reference is null.");
+            }
+
+            if (animator.runtimeAnimatorController == null)
+            {
+                return TriValidationResult.Error("Animator has no controller assigned.");
+            }
+
+            var (allParameters, allFilteredParameters) = AnimatorParameterHelper.GetParameters(animator, Attribute.ParameterType);
+
+            if (property.ValueType == typeof(string))
+            {
+                var currentValue = (string)property.Value;
+
+                if (string.IsNullOrEmpty(currentValue))
+                {
+                    return TriValidationResult.Valid;
+                }
+
+                if (!allParameters.Names.Contains(currentValue))
+                {
+                    string label = AnimatorParameterHelper.GetInvalidParameterLabel(animator, currentValue);
+                    return TriValidationResult.Error($"Parameter {label} not found in animator.")
+                        .WithFix(() => property.SetValue(null), "Clear value");
+                }
+                if (!allFilteredParameters.Names.Contains(currentValue))
+                {
+                    string label = AnimatorParameterHelper.GetInvalidParameterLabel(animator, currentValue);
+                    return TriValidationResult.Error($"Parameter {label} is not of the expected type ({Attribute.ParameterType}).")
+                        .WithFix(() => property.SetValue(null), "Clear value");
+                }
+            }
+            
+            if (property.ValueType == typeof(int))
+            {
+                var currentValue = (int)property.Value;
+                if (currentValue == 0)
+                {
+                    return TriValidationResult.Valid;
+                }
+
+                if (!allParameters.Hashes.Contains(currentValue))
+                {
+                    string label = AnimatorParameterHelper.GetInvalidParameterLabel(animator, currentValue);
+                    return TriValidationResult.Error($"Parameter {label} not found in animator.")
+                        .WithFix(() => property.SetValue(0), "Clear value");
+                }
+                if (!allFilteredParameters.Hashes.Contains(currentValue))
+                {
+                    string label = AnimatorParameterHelper.GetInvalidParameterLabel(animator, currentValue);
+                    return TriValidationResult.Error($"Parameter {label} is not of the expected type ({Attribute.ParameterType}).")
+                        .WithFix(() => property.SetValue(0), "Clear value");
+                }
+            }
+
+            return TriValidationResult.Valid;
+        }
+    }
+}

--- a/Editor.Extras/Validators/AnimatorParameterAttributeValidator.cs.meta
+++ b/Editor.Extras/Validators/AnimatorParameterAttributeValidator.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: dc6bfe89dfc29004d86b92c8aff6f5f7

--- a/Editor.Extras/Validators/MaterialPropertyAttributeValidator.cs
+++ b/Editor.Extras/Validators/MaterialPropertyAttributeValidator.cs
@@ -1,0 +1,85 @@
+using System.Linq;
+using TriInspector;
+using TriInspector.Drawers;
+using TriInspector.Validators;
+using UnityEngine;
+
+[assembly: RegisterTriAttributeValidator(typeof(MaterialPropertyAttributeValidator), ApplyOnArrayElement = true)]
+
+namespace TriInspector.Validators
+{
+    public class MaterialPropertyAttributeValidator : TriAttributeValidator<MaterialPropertyAttribute>
+    {
+        private MaterialPropertyHelper.ResolvedParams _resolvedParams;
+
+        public override TriExtensionInitializationResult Initialize(TriPropertyDefinition propertyDefinition)
+        {
+            _resolvedParams = MaterialPropertyHelper.Initialize(propertyDefinition, Attribute);
+            return _resolvedParams.ErrorResult;
+        }
+
+        public override TriValidationResult Validate(TriProperty property)
+        {
+            var material = _resolvedParams.MaterialResolver.GetValue(property);
+
+            if (material == null)
+            {
+                return TriValidationResult.Error("Animator reference is null.");
+            }
+
+            if (material.shader == null)
+            {
+                return TriValidationResult.Error("Material has no shader assigned.");
+            }
+
+            var (allParameters, allFilteredParameters) = MaterialPropertyHelper.GetProperties(material, Attribute.PropertyType);
+
+            if (property.ValueType == typeof(string))
+            {
+                var currentValue = (string)property.Value;
+
+                if (string.IsNullOrEmpty(currentValue))
+                {
+                    return TriValidationResult.Valid;
+                }
+
+                if (!allParameters.Names.Contains(currentValue))
+                {
+                    string label = MaterialPropertyHelper.GetInvalidPropertyLabel(material, currentValue);
+                    return TriValidationResult.Error($"Parameter {label} not found in animator.")
+                        .WithFix(() => property.SetValue(null), "Clear value");
+                }
+                if (!allFilteredParameters.Names.Contains(currentValue))
+                {
+                    string label = MaterialPropertyHelper.GetInvalidPropertyLabel(material, currentValue);
+                    return TriValidationResult.Error($"Parameter {label} is not of the expected type ({Attribute.PropertyType}).")
+                        .WithFix(() => property.SetValue(null), "Clear value");
+                }
+            }
+
+            if (property.ValueType == typeof(int))
+            {
+                var currentValue = (int)property.Value;
+                if (currentValue == 0)
+                {
+                    return TriValidationResult.Valid;
+                }
+
+                if (!allParameters.Hashes.Contains(currentValue))
+                {
+                    string label = MaterialPropertyHelper.GetInvalidPropertyLabel(material, currentValue);
+                    return TriValidationResult.Error($"Parameter {label} not found in animator.")
+                        .WithFix(() => property.SetValue(0), "Clear value");
+                }
+                if (!allFilteredParameters.Hashes.Contains(currentValue))
+                {
+                    string label = MaterialPropertyHelper.GetInvalidPropertyLabel(material, currentValue);
+                    return TriValidationResult.Error($"Parameter {label} is not of the expected type ({Attribute.PropertyType}).")
+                        .WithFix(() => property.SetValue(0), "Clear value");
+                }
+            }
+
+            return TriValidationResult.Valid;
+        }
+    }
+}

--- a/Editor.Extras/Validators/MaterialPropertyAttributeValidator.cs.meta
+++ b/Editor.Extras/Validators/MaterialPropertyAttributeValidator.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d4a550db5df592a41acf94cf152689f8

--- a/Editor.Samples/Decorators/Decorators_AnimatorParameterSample.cs
+++ b/Editor.Samples/Decorators/Decorators_AnimatorParameterSample.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+using TriInspector;
+
+public class Decorators_AnimatorParameterSample : ScriptableObject
+{
+    [AnimatorParameter(nameof(animator))]
+    public string parameterName;
+
+    [AnimatorParameter(nameof(animator), AnimatorControllerParameterType.Float)]
+    public int parameterHash;
+
+    public Animator animator;
+}

--- a/Editor.Samples/Decorators/Decorators_AnimatorParameterSample.cs.meta
+++ b/Editor.Samples/Decorators/Decorators_AnimatorParameterSample.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4b4d2c47397658a4c805315bfcb7dadf

--- a/Editor.Samples/Decorators/Decorators_MaterialPropertySample.cs
+++ b/Editor.Samples/Decorators/Decorators_MaterialPropertySample.cs
@@ -1,0 +1,14 @@
+using TriInspector;
+using UnityEngine;
+using UnityEngine.Rendering;
+
+public class Decorators_MaterialPropertySample : ScriptableObject
+{
+    [MaterialProperty(nameof(material))]
+    public string propertyName;
+
+    [MaterialProperty(nameof(material), ShaderPropertyType.Color)]
+    public int propertyHash;
+
+    public Material material;
+}

--- a/Editor.Samples/Decorators/Decorators_MaterialPropertySample.cs.meta
+++ b/Editor.Samples/Decorators/Decorators_MaterialPropertySample.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b7e2cfad48ebb41408e6c211c4b7ef20

--- a/Runtime/Attributes/Decorators/AnimatorParameterAttribute.cs
+++ b/Runtime/Attributes/Decorators/AnimatorParameterAttribute.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Diagnostics;
+using UnityEngine;
+
+namespace TriInspector
+{
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false)]
+    [Conditional("UNITY_EDITOR")]
+    public class AnimatorParameterAttribute : Attribute
+    {
+        public string AnimatorFieldName { get; }
+        public AnimatorControllerParameterType? ParameterType { get; }
+
+        public AnimatorParameterAttribute(string animatorFieldName)
+        {
+            AnimatorFieldName = animatorFieldName;
+        }
+        public AnimatorParameterAttribute(string animatorFieldName, AnimatorControllerParameterType parameterType) : this(animatorFieldName)
+        {
+            ParameterType = parameterType;
+        }
+    }
+}

--- a/Runtime/Attributes/Decorators/AnimatorParameterAttribute.cs.meta
+++ b/Runtime/Attributes/Decorators/AnimatorParameterAttribute.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 963f2e15046d9a74bbe4d28d06538974

--- a/Runtime/Attributes/Decorators/MaterialPropertyAttribute.cs
+++ b/Runtime/Attributes/Decorators/MaterialPropertyAttribute.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Diagnostics;
+using UnityEngine;
+using UnityEngine.Rendering;
+
+namespace TriInspector
+{
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false)]
+    [Conditional("UNITY_EDITOR")]
+    public class MaterialPropertyAttribute : Attribute
+    {
+        public string MaterialFieldName { get; }
+        public ShaderPropertyType? PropertyType { get; }
+
+        public MaterialPropertyAttribute(string materialFieldName)
+        {
+            MaterialFieldName = materialFieldName;
+        }
+        public MaterialPropertyAttribute(string animatorFieldName, ShaderPropertyType parameterType) : this(animatorFieldName)
+        {
+            PropertyType = parameterType;
+        }
+    }
+}

--- a/Runtime/Attributes/Decorators/MaterialPropertyAttribute.cs.meta
+++ b/Runtime/Attributes/Decorators/MaterialPropertyAttribute.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6fa7f4cf7a293384c95c8097ba153058


### PR DESCRIPTION
This pull request introduces two new attributes, `AnimatorParameter` and `MaterialProperty`, providing generate dropdowns listing parameters or properties from a referenced Animator or Material
These dropdowns populate dynamically based on the referenced component, ensuring that only valid options can be selected, with optional filtering by type.
**Discussion #200** **Discussion #201**.

### Changes:
* Added `AnimatorParameterAttribute` and its corresponding drawer, validator and sample class.
* Added `MaterialPropertyAttribute` and its corresponding drawer, validator and sample class.

### Impact:
* `AnimatorParameter` automatically lists all available parameters from the target Animator, with optional filtering by parameter type.
* `MaterialProperty` automatically displays valid shader properties from the target Material, including support for specific types (Float, Color, Vector, Texture, etc.).

#### AnimatorParameter

<img width="1000" height="130" alt="AnimatorParameter_Inspector" src="https://github.com/user-attachments/assets/9cd8837e-3d78-4b5f-808f-27bf16635099" />


```csharp
[AnimatorParameter(nameof(animator))]
public string parameterName;

[AnimatorParameter(nameof(animator), AnimatorControllerParameterType.Float)]
public int parameterHash;

public Animator animator;
```

#### MaterialProperty

<img width="1000" height="130" alt="MaterialProperty_Inspector" src="https://github.com/user-attachments/assets/09eab958-aa13-43c6-a780-4a2d4d2704bb" />


```csharp
[MaterialProperty(nameof(material))]
public string propertyName;

[MaterialProperty(nameof(material), ShaderPropertyType.Color)]
public int propertyHash;

public Material material;
```