### PR TITLE
[Fix] Group fields are hidden

### DIFF
--- a/Editor/Elements/TriPropertyCollectionBaseElement.cs
+++ b/Editor/Elements/TriPropertyCollectionBaseElement.cs
@@ -114,7 +114,23 @@ namespace TriInspector.Elements
 
                 AddPropertyChild(groupElement, property);
             }
-
+            else
+            {
+                bool found = false;
+                for (var i = 0; i < ChildrenCount; ++i)
+                {
+                    if (GetChild(i) == groupElement)
+                    {
+                        found = true;
+                        break;
+                    }
+                }
+                if (!found)
+                {
+                    groupElement.RemoveAllChildren();
+                    AddPropertyChild(groupElement, property);
+                }
+            }
             return groupElement;
         }
 


### PR DESCRIPTION
Related to #202.
There was also a bug where fields attributed with [Group] were hidden when displaying a class via SerializeReference, but it has now been fixed.